### PR TITLE
README: Fix toolbox incantation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you use distrobox:
     
 If you use toolbx:
 
-    toolbox create -i ghcr.io/ublue-os/boxkit -n boxkit
+    toolbox create -i ghcr.io/ublue-os/boxkit -c boxkit
     toolbox enter boxkit
 
 ### Pull down your config


### PR DESCRIPTION


```
wjt@camille:~$ toolbox create --help -i ghcr.io/ublue-os/boxkit -n boxkit --help
Error: unknown shorthand flag: 'n' in -n
Run 'toolbox --help' for usage.
wjt@camille:~$ toolbox create --help
wjt@camille:~$ toolbox create -i ghcr.io/ublue-os/boxkit -c boxkit
Image required to create toolbox container.
Download ghcr.io/ublue-os/boxkit (500MB)? [y/N]: y
Created container: boxkit
Enter with: toolbox enter boxkit
```

Although having written this, I can't actually enter the container:

```
wjt@camille:~$ toolbox enter boxkit
Error: invalid entry point PID of container boxkit
```

This is probably a separate issue.