### PR TITLE
chore: add image metadata

### DIFF
--- a/.github/workflows/build-boxkit.yml
+++ b/.github/workflows/build-boxkit.yml
@@ -29,6 +29,16 @@ jobs:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
         uses: actions/checkout@v3
+        
+      # Build metadata
+      - name: Image Metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          labels: |
+            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/boxkit/main/README.md
 
       # Build image using Buildah action
       - name: Build Image
@@ -39,8 +49,9 @@ jobs:
             ./Containerfile
           image: ${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAGS }}
-          oci: true
-
+          labels: ${{ steps.meta.outputs.labels }}
+          oci: false
+          
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12
       - name: Lowercase Registry


### PR DESCRIPTION
This will add proper labels to the images, the io.artifacthub labels are so we can show up on artifacthub