### PR TITLE
feat: Replace exa with eza

### DIFF
--- a/extra-packages
+++ b/extra-packages
@@ -7,7 +7,7 @@ clipboard
 cosign
 dbus-x11
 direnv
-exa
+eza
 ffmpeg
 fzf
 github-cli


### PR DESCRIPTION
[exa](https://github.com/ogham/exa) is unmaintained and the recommendation in the git repository is to use the fork [eza](https://github.com/eza-community/eza) which [Alpine upstream](https://gitlab.alpinelinux.org/alpine/aports/-/issues/15264) is also doing.
