### PR TITLE
fix: dead cosign docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ These images are signed with sisgstore's [cosign](https://docs.sigstore.dev/quic
 
     cosign verify --key cosign.pub ghcr.io/ublue-os/boxkit
     
-If you're forking this repo you should [read the docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets) on keeping secrets in github. You need to [generate a new keypair](https://docs.sigstore.dev/cosign/overview/) with cosign. The public key can be in your public repo (your users need it to check the signatures), and you can paste the private key in Settings -> Secrets -> Actions.
+If you're forking this repo you should [read the docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets) on keeping secrets in github. You need to [generate a new keypair](https://docs.sigstore.dev/cosign/key_management/signing_with_self-managed_keys/) with cosign. The public key can be in your public repo (your users need it to check the signatures), and you can paste the private key in Settings -> Secrets -> Actions.
 
 ## Finding Good Base Images
 


### PR DESCRIPTION
another instance of the same dead URL (like before) but I replaced it with the page that actually explains the key gen part.
Docs were probably split up at some point.