### PR TITLE
Use googleapis instead of deprecated google-github-actions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: simple
           package-name: release-please-action


### PR DESCRIPTION
The `release-please-action` from [`google-github-actions`](https://github.com/google-github-actions/release-please-action) was recently deprecated and moved to [`googleapis`](https://github.com/googleapis/release-please-action)

This is a simple MR that changes the Github Action being used accordingly.