### PR TITLE
fix: add back the push trigger

### DIFF
--- a/.github/workflows/build-boxkit.yml
+++ b/.github/workflows/build-boxkit.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     branches:
       - main
-  merge_group:
   push:
-    branches-ignore:
-      - gh-readonly-queue/*
+    branches:
+      - main
+    paths-ignore: # don't rebuild on documentation change
+      - '**.md'
   schedule:
     - cron: '0 0 * * TUE'
 
@@ -30,8 +31,8 @@ jobs:
           - boxkit
        #- fedora-example # Included as an example to demonstrate multi-image builds, uncomment to build the fedora-example container too
     steps:
-      # Checkout push-to-registry action GitHub repository
-      - name: Checkout Push to Registry action
+      # Clone code to runner
+      - name: Checkout
         uses: actions/checkout@v4
 
       # Build metadata

--- a/.github/workflows/build-boxkit.yml
+++ b/.github/workflows/build-boxkit.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches:
       - main
-  merge_group:    
+  merge_group:
+  push:
+    branches-ignore:
+      - gh-readonly-queue/*
   schedule:
     - cron: '0 0 * * TUE'
 


### PR DESCRIPTION
The README shows this repository is intended to be cloned and maintained by others, rather than being consumed directly from ublue-os/boxkit. 

Most users don't want to deal with pull requests (PRs) and merge queues in their own repositories, so images aren't updated automatically when new commits are pushed. 

This PR updates the triggers so that any changes pushed to the main branch will trigger a build, removing the need for a merge queue in forks.

