### PR TITLE
 refactor(ci): free disk space before image build

### DIFF
--- a/.github/workflows/build-boxkit.yml
+++ b/.github/workflows/build-boxkit.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # Remove unused stuff to free disk space
       - name: Free Disk Space
-        uses: endersonmenezes/free-disk-space@6c4664f43348c8c7011b53488d5ca65e9fc5cd1a
+        uses: endersonmenezes/free-disk-space@b40e4c897158bd5efbb48f990ed6718db182959b
         with:
           remove_android: true
           remove_dotnet: true

--- a/.github/workflows/build-boxkit.yml
+++ b/.github/workflows/build-boxkit.yml
@@ -31,6 +31,23 @@ jobs:
           - boxkit
        #- fedora-example # Included as an example to demonstrate multi-image builds, uncomment to build the fedora-example container too
     steps:
+      # Remove unused stuff to free disk space
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@6c4664f43348c8c7011b53488d5ca65e9fc5cd1a
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: false
+          remove_swap: true
+          # uncomment below line to free another ~5 GiB for the price of another ~90s runtime cost
+          # remove_packages: "azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox postgresql* temurin-* *llvm* mysql* dotnet-sdk-*"
+          remove_packages_one_command: true
+          remove_folders: "/usr/share/swift /usr/share/miniconda /usr/share/az* /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell /usr/local/julia /usr/local/aws-cli /usr/local/aws-sam-cli /usr/share/gradle"
+          rm_cmd: "rmz"  # see https://github.com/SUPERCILEX/fuc for more info
+          rmz_version: "3.1.1"
+          testing: false
+
       # Clone code to runner
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/.github/workflows/build-boxkit.yml
+++ b/.github/workflows/build-boxkit.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # Remove unused stuff to free disk space
       - name: Free Disk Space
-        uses: endersonmenezes/free-disk-space@b40e4c897158bd5efbb48f990ed6718db182959b
+        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1
         with:
           remove_android: true
           remove_dotnet: true


### PR DESCRIPTION
I've ran into [`no space left on device` errors](https://github.com/salim-b/boxkit/actions/runs/19449262521/job/55650526728#step:4:4207) in my boxkit pipeline and fixed that by running [`endersonmenezes/free-disk-space`](https://github.com/endersonmenezes/free-disk-space) as the very first step in the workflow.

I assume sooner or later other users building ample dev toolboxes will likely be affected by such disk space shortage, too, which is why I propose to include this step here upstream. This also lets dependabot track updates to the action.

With the current config, this step [frees up ~30GiB of disk space for an additional 16s of runtime cost](https://github.com/salim-b/boxkit/actions/runs/19474661510/job/55731195863), which I think is acceptable to use as the default. Freeing up even more space by uninstalling unnecessary DEB packages via `remove_packages` costs disproportionately more runtime, so I refrained from this.

There's [more than a dozen actions for the same purpose available](https://github.com/marketplace?query=disk+space&type=actions). [`endersonmenezes/free-disk-space`](https://github.com/endersonmenezes/free-disk-space) appears to be well tested (based on the popular but unmaintained [`jlumbroso/free-disk-space`](https://github.com/jlumbroso/free-disk-space)) and actively maintained while including nice optimizations like `remove_packages_one_command: true` (though not relevant for our default config) and `rm_cmd: "rmz"` employing the Rust-based [`rmz` utility](https://github.com/SUPERCILEX/fuc).