### PR TITLE
fix: add shim for `xdg-open`

### DIFF
--- a/scripts/distrobox-shims.sh
+++ b/scripts/distrobox-shims.sh
@@ -6,3 +6,4 @@ ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/flatpak
 ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/podman
 ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/rpm-ostree
 ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/transactional-update
+ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/xdg-open


### PR DESCRIPTION
(Distrobox only adds the shim automatically if `xdg-open` is [not present](https://github.com/89luca89/distrobox/blob/2995df501b31338f6b83de876ab50bed9826c9d9/distrobox-init#L1834-L1840) in the container)